### PR TITLE
Set limit to 1 in get_wallet_nfts example

### DIFF
--- a/docs/evm_api/nft.md
+++ b/docs/evm_api/nft.md
@@ -767,7 +767,7 @@ params = {
     "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045", 
     "chain": "eth", 
     "format": "decimal", 
-    "limit": 0, 
+    "limit": 1, 
     "exclude_spam": True, 
     "token_addresses": [], 
     "cursor": "", 


### PR DESCRIPTION
### Issue Description

Using the existing example for `evm_api.nft.get_wallet_nfts` returns the following error: 
`HTTP response body: b'{"message":"limit must not be less than 1"}'`

### Solution Description

![image](https://github.com/MoralisWeb3/Moralis-Python-SDK/assets/35845239/fa3e356a-75d0-4b57-a049-28ee9167bff9)

Note: There may be other instances where this occurs, as I see `"limit": 0` used in other examples. Unfortunately I lack the time to check them all myself.