### PR TITLE
Support for Pydantic V2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ frozendict==2.3.4
 importlib-metadata==5.0.0
 python-dateutil==2.8.2
 twine==4.0.1
-typing_extensions==4.3.0
+typing_extensions==4.9.0
 urllib3==1.26.12
 Jinja2==3.1.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ REQUIRES = [
     "certifi >= 14.5.14",
     "frozendict ~= 2.3.4",
     "python-dateutil ~= 2.8.2",
-    "typing_extensions ~= 4.3.0",
+    "typing_extensions ~= 4.9.0",
     "urllib3 ~= 1.26.7",
 ]
 


### PR DESCRIPTION
---
name: Support for Pydantic v2
about: bump typing_extensions to 4.9.0
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-Python-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-Python-SDK/blob/main/CODE_STYLE.md)
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated Typescript definitions when needed

### Issue Description
we're using pydantic v2 in our code base. I bumped `typing_extensions` to a version suitable for Pydantic v2.

### Related issue: N/A

### Solution Description
simple bump. checked some evm_api calls and everything works like before :)
